### PR TITLE
abspath when checking if str is file

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -4,7 +4,7 @@ import os
 import platform
 import tempfile
 
-__version__ = "0.2.12"
+__version__ = "0.2.13"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()

--- a/glasswall/utils.py
+++ b/glasswall/utils.py
@@ -403,14 +403,18 @@ def validate_xml(xml: Union[str, bytes, bytearray, io.BytesIO, "glasswall.conten
         TypeError: if the type of arg "xml" is invalid
     """
     try:
-        # Get tree from file
-        if isinstance(xml, str) and os.path.isfile(xml):
-            tree = etree.parse(xml)
+        # Get tree from file/str
+        if isinstance(xml, str):
+            try:
+                is_file = os.path.isfile(os.path.abspath(xml))
+            except Exception:
+                is_file = False
 
-        # Get tree from xml string
-        elif isinstance(xml, str):
-            xml = xml.encode("utf-8")
-            tree = etree.fromstring(xml)
+            if is_file:
+                tree = etree.parse(xml)
+            else:
+                xml = xml.encode("utf-8")
+                tree = etree.fromstring(xml)
 
         # Get tree from bytes, bytearray, io.BytesIO
         elif isinstance(xml, (bytes, bytearray, io.BytesIO)):


### PR DESCRIPTION
Fixes an issue PA encountered in the imagemagick conversion script relating to the path to config file being passed in as a relative path instead of absolute path.