### PR TITLE
Users/aroberts/fix get library for libraries with multiple aliases

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -4,7 +4,7 @@ import os
 import platform
 import tempfile
 
-__version__ = "0.2.18"
+__version__ = "0.2.19"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()


### PR DESCRIPTION
Fixed a bug where utils.get_library was returning earlier than intended instead of iterating all aliases of a library.