### PR TITLE
Users/aroberts/wordsearch redact fix writing of empty buffers

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 import platform
 import tempfile
 
-__version__ = "0.2.31"
+__version__ = "0.2.32"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()

--- a/glasswall/libraries/word_search/word_search.py
+++ b/glasswall/libraries/word_search/word_search.py
@@ -141,16 +141,18 @@ class WordSearch(Library):
             log.debug(f"\n\tinput_file: {input_file_repr}\n\toutput_file: {output_file_repr}\n\toutput_report: {output_report_repr}\n\thomoglyphs: {homoglyphs_repr}\n\tstatus: {gw_return_object.status}\n\tcontent_management_policy:\n{content_management_policy}")
 
         # Write output file
-        if isinstance(output_file, str):
-            os.makedirs(os.path.dirname(output_file), exist_ok=True)
-            with open(output_file, "wb") as f:
-                f.write(gw_return_object.output_file)
+        if gw_return_object.output_file:
+            if isinstance(output_file, str):
+                os.makedirs(os.path.dirname(output_file), exist_ok=True)
+                with open(output_file, "wb") as f:
+                    f.write(gw_return_object.output_file)
 
         # Write output report
-        if isinstance(output_report, str):
-            os.makedirs(os.path.dirname(output_report), exist_ok=True)
-            with open(output_report, "wb") as f:
-                f.write(gw_return_object.output_report)
+        if gw_return_object.output_report:
+            if isinstance(output_report, str):
+                os.makedirs(os.path.dirname(output_report), exist_ok=True)
+                with open(output_report, "wb") as f:
+                    f.write(gw_return_object.output_report)
 
         if input_file_bytes and not gw_return_object.output_file:
             # input_file_bytes was not empty but output_file is unexpectedly empty


### PR DESCRIPTION
Fix a bug that could cause empty buffers to be written to file when redact had failed.