### PR TITLE
Users/aroberts/fix editor validate license run mode

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 import platform
 import tempfile
 
-__version__ = "0.2.32"
+__version__ = "0.2.33"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()

--- a/glasswall/libraries/editor/editor.py
+++ b/glasswall/libraries/editor/editor.py
@@ -37,7 +37,8 @@ class Editor(Library):
         try:
             self.protect_file(
                 input_file=b"BM:\x00\x00\x00\x00\x00\x00\x006\x00\x00\x00(\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x18\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\x00",
-                raise_unsupported=True
+                raise_unsupported=True,
+                content_management_policy=glasswall.content_management.policies.Editor(config={"sysConfig": {"run_mode": "editoronly"}})
             )
             log.debug(f"{self.__class__.__name__} license validated successfully.")
         except errors.EditorError:


### PR DESCRIPTION
Fix a bug where Editor license validation could fail if the Rebuild library is not present.