### PR TITLE
update actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: [3.6, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
Fix for the below deprecation warning:



<html>
<body>
<!--StartFragment--><div class="mt-1 mb-3 px-3" style="box-sizing: border-box; margin-top: var(--base-size-4, 4px) !important; margin-bottom: var(--base-size-16, 16px) !important; padding-right: var(--base-size-16, 16px) !important; padding-left: var(--base-size-16, 16px) !important; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="mx-0 mx-md-1" style="box-sizing: border-box; margin-right: var(--base-size-4, 4px) !important; margin-left: var(--base-size-4, 4px) !important;"><h4 class="text-bold" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px; font-size: var(--h4-size, 16px); font-weight: var(--base-text-weight-semibold, 600) !important;">Annotations</h4><div class="color-fg-muted text-small" style="box-sizing: border-box; color: var(--color-fg-muted) !important; font-size: var(--h6-size, 12px) !important;">1 warning</div></div></div>

deployNode.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
--


<!--EndFragment-->
</body>
</html>Annotations
1 warning
[deploy](https://github.com/gw-engineering/glasswall-python-wrapper/actions/runs/5013929434/jobs/8987600655)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.





