### PR TITLE
write analysis report if buffer is populated, even on failure

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 import platform
 import tempfile
 
-__version__ = "1.0.7"
+__version__ = "2.0.0"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()


### PR DESCRIPTION
Changes the behaviour of Editor and Rebuild's `analyse_file` method for non-conforming files.

**Previous behaviour for non-conforming files:**
The analysis report was not written or returned. An exception was raised. If `raise_unsupported=False` was specified then `None` was returned.

**New behaviour for non-conforming files:**
If the analysis report buffer and buffer length are not populated:
An exception is raised unless `raise_unsupported=False`, in which case `None` is returned.

If the analysis report buffer and buffer length are populated:
In file to file and memory to file modes an analysis report will be written to the specified `output_file` path. An exception is raised unless `raise_unsupported=False`, in which case the analysis report bytes are returned.

In file to memory and memory to memory modes (when `output_file=None`) an exception is raised unless `raise_unsupported=False`, in which case the analysis report bytes are returned.