### PR TITLE
ArchiveManager code refactor and default include analysis report argument change

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 import platform
 import tempfile
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()

--- a/glasswall/libraries/archive_manager/archive_manager.py
+++ b/glasswall/libraries/archive_manager/archive_manager.py
@@ -908,7 +908,7 @@ class ArchiveManager(Library):
 
         return gw_return_object
 
-    def import_directory(self, input_directory: str, output_directory: Optional[str], output_report_directory: Optional[str] = None, content_management_policy: Union[None, str, bytes, bytearray, io.BytesIO, glasswall.content_management.policies.ArchiveManager] = None, include_analysis_report: Optional[bool] = True, raise_unsupported: bool = True):
+    def import_directory(self, input_directory: str, output_directory: Optional[str], output_report_directory: Optional[str] = None, content_management_policy: Union[None, str, bytes, bytearray, io.BytesIO, glasswall.content_management.policies.ArchiveManager] = None, include_analysis_report: Optional[bool] = False, raise_unsupported: bool = True):
         """ Calls import_archive on each file in input_directory. The imported archives are written to output_directory maintaining the same directory structure as input_directory.
 
         Args:
@@ -916,7 +916,7 @@ class ArchiveManager(Library):
             output_directory (Optional[str], optional): Default None. If str, the output directory where the archives will be written.
             output_report_directory (Optional[str], optional): Default None. If str, the output directory where xml reports for each archive will be written.
             content_management_policy (Union[None, str, bytes, bytearray, io.BytesIO, glasswall.content_management.policies.ArchiveManager], optional): The content management policy to apply.
-            include_analysis_report (Optional[bool], optional): Default True. If True, write the analysis report into the imported archive.
+            include_analysis_report (Optional[bool], optional): Default False. If True, write the analysis report into the imported archive.
             raise_unsupported (bool, optional): Default True. Raise exceptions when Glasswall encounters an error. Fail silently if False.
 
         Returns:

--- a/glasswall/libraries/archive_manager/archive_manager.py
+++ b/glasswall/libraries/archive_manager/archive_manager.py
@@ -311,9 +311,10 @@ class ArchiveManager(Library):
             raise TypeError(content_management_policy)
 
         # Convert string path arguments to absolute paths
+        if isinstance(input_file, str):
+            input_file = os.path.abspath(input_file)
         if isinstance(output_file, str):
             output_file = os.path.abspath(output_file)
-
         if isinstance(output_report, str):
             output_report = os.path.abspath(output_report)
 
@@ -336,38 +337,60 @@ class ArchiveManager(Library):
 
         # API function declaration
         self.library.GwFileProtectAndReportArchive.argtypes = [
-            ct.c_void_p,
-            ct.c_size_t,
-            ct.POINTER(ct.c_void_p),
-            ct.POINTER(ct.c_size_t),
-            ct.POINTER(ct.c_void_p),
-            ct.POINTER(ct.c_size_t),
-            ct.c_char_p
+            ct.c_void_p,  # void *inputBuffer
+            ct.c_size_t,  # size_t inputBufferLength
+            ct.POINTER(ct.c_void_p),  # void **outputFileBuffer
+            ct.POINTER(ct.c_size_t),  # size_t *outputFileBufferLength
+            ct.POINTER(ct.c_void_p),  # void **outputReportBuffer
+            ct.POINTER(ct.c_size_t),  # size_t *outputReportBufferLength
+            ct.c_char_p  # const char *xmlConfigString
         ]
-
         # Variable initialisation
-        input_buffer_bytearray = bytearray(input_file_bytes)
-
-        ct_input_buffer = (ct.c_ubyte * len(input_buffer_bytearray)).from_buffer(input_buffer_bytearray)  # void *inputBuffer
-        ct_input_buffer_length = ct.c_size_t(len(input_file_bytes))  # size_t inputBufferLength
-        ct_output_buffer = ct.c_void_p()  # void **outputFileBuffer
-        ct_output_buffer_length = ct.c_size_t()  # size_t *outputFileBufferLength
-        ct_output_report_buffer = ct.c_void_p()  # void **outputAnalysisReportBuffer
-        ct_output_report_buffer_length = ct.c_size_t()  # size_t *outputAnalysisReportBufferLength
-        ct_content_management_policy = ct.c_char_p(content_management_policy.encode())  # const char *xmlConfigString
         gw_return_object = glasswall.GwReturnObj()
+        gw_return_object.input_buffer = ct.create_string_buffer(input_file_bytes)
+        gw_return_object.input_buffer_length = ct.c_size_t(len(input_file_bytes))
+        gw_return_object.output_buffer = ct.c_void_p()
+        gw_return_object.output_buffer_length = ct.c_size_t()
+        gw_return_object.output_report_buffer = ct.c_void_p()
+        gw_return_object.output_report_buffer_length = ct.c_size_t()
+        gw_return_object.content_management_policy = ct.c_char_p(content_management_policy.encode())
 
         with utils.CwdHandler(new_cwd=self.library_path):
             # API call
             gw_return_object.status = self.library.GwFileProtectAndReportArchive(
-                ct.byref(ct_input_buffer),
-                ct_input_buffer_length,
-                ct.byref(ct_output_buffer),
-                ct.byref(ct_output_buffer_length),
-                ct.byref(ct_output_report_buffer),
-                ct.byref(ct_output_report_buffer_length),
-                ct_content_management_policy
+                ct.byref(gw_return_object.input_buffer),
+                gw_return_object.input_buffer_length,
+                ct.byref(gw_return_object.output_buffer),
+                ct.byref(gw_return_object.output_buffer_length),
+                ct.byref(gw_return_object.output_report_buffer),
+                ct.byref(gw_return_object.output_report_buffer_length),
+                gw_return_object.content_management_policy
             )
+
+        if gw_return_object.output_buffer and gw_return_object.output_buffer_length:
+            gw_return_object.output_file = utils.buffer_to_bytes(
+                gw_return_object.output_buffer,
+                gw_return_object.output_buffer_length
+            )
+        if gw_return_object.output_report_buffer and gw_return_object.output_report_buffer_length:
+            gw_return_object.output_report = utils.buffer_to_bytes(
+                gw_return_object.output_report_buffer,
+                gw_return_object.output_report_buffer_length
+            )
+
+        # Write output file
+        if hasattr(gw_return_object, "output_file"):
+            if isinstance(output_file, str):
+                os.makedirs(os.path.dirname(output_file), exist_ok=True)
+                with open(output_file, "wb") as f:
+                    f.write(gw_return_object.output_file)
+
+        # Write output report
+        if hasattr(gw_return_object, "output_report"):
+            if isinstance(output_report, str):
+                os.makedirs(os.path.dirname(output_report), exist_ok=True)
+                with open(output_report, "wb") as f:
+                    f.write(gw_return_object.output_report)
 
         input_file_repr = f"{type(input_file)} length {len(input_file)}" if isinstance(input_file, (bytes, bytearray,)) else input_file.__sizeof__() if isinstance(input_file, io.BytesIO) else input_file
         if gw_return_object.status not in successes.success_codes:
@@ -376,29 +399,6 @@ class ArchiveManager(Library):
                 raise errors.error_codes.get(gw_return_object.status, errors.UnknownErrorCode)(gw_return_object.status)
         else:
             log.debug(f"\n\tinput_file: {input_file_repr}\n\toutput_file: {output_file}\n\tstatus: {gw_return_object.status}")
-
-        gw_return_object.output_file = utils.buffer_to_bytes(
-            ct_output_buffer,
-            ct_output_buffer_length
-        )
-        gw_return_object.output_report = utils.buffer_to_bytes(
-            ct_output_report_buffer,
-            ct_output_report_buffer_length
-        )
-
-        # Write output file
-        if gw_return_object.output_file:
-            if isinstance(output_file, str):
-                os.makedirs(os.path.dirname(output_file), exist_ok=True)
-                with open(output_file, "wb") as f:
-                    f.write(gw_return_object.output_file)
-
-        # Write output report
-        if gw_return_object.output_report:
-            if isinstance(output_report, str):
-                os.makedirs(os.path.dirname(output_report), exist_ok=True)
-                with open(output_report, "wb") as f:
-                    f.write(gw_return_object.output_report)
 
         self.release()
 

--- a/glasswall/libraries/archive_manager/archive_manager.py
+++ b/glasswall/libraries/archive_manager/archive_manager.py
@@ -658,9 +658,10 @@ class ArchiveManager(Library):
             raise TypeError(content_management_policy)
 
         # Convert string path arguments to absolute paths
+        if isinstance(input_file, str):
+            input_file = os.path.abspath(input_file)
         if isinstance(output_file, str):
             output_file = os.path.abspath(output_file)
-
         if isinstance(output_report, str):
             output_report = os.path.abspath(output_report)
 
@@ -683,38 +684,61 @@ class ArchiveManager(Library):
 
         # API function declaration
         self.library.GwFileExportArchive.argtypes = [
-            ct.c_void_p,
-            ct.c_size_t,
-            ct.POINTER(ct.c_void_p),
-            ct.POINTER(ct.c_size_t),
-            ct.POINTER(ct.c_void_p),
-            ct.POINTER(ct.c_size_t),
-            ct.c_char_p
+            ct.c_void_p,  # void *inputBuffer
+            ct.c_size_t,  # size_t inputBufferLength
+            ct.POINTER(ct.c_void_p),  # void **outputFileBuffer
+            ct.POINTER(ct.c_size_t),  # size_t *outputFileBufferLength
+            ct.POINTER(ct.c_void_p),  # void **outputReportBuffer
+            ct.POINTER(ct.c_size_t),  # size_t *outputReportBufferLength
+            ct.c_char_p  # const char *xmlConfigString
         ]
 
         # Variable initialisation
-        input_buffer_bytearray = bytearray(input_file_bytes)
-
-        ct_input_buffer = (ct.c_ubyte * len(input_buffer_bytearray)).from_buffer(input_buffer_bytearray)  # void *inputBuffer
-        ct_input_buffer_length = ct.c_size_t(len(input_file_bytes))  # size_t inputBufferLength
-        ct_output_buffer = ct.c_void_p()  # void **outputFileBuffer
-        ct_output_buffer_length = ct.c_size_t()  # size_t *outputFileBufferLength
-        ct_output_report_buffer = ct.c_void_p()  # void **outputReportBuffer
-        ct_output_report_buffer_length = ct.c_size_t()  # size_t *outputReportBufferLength
-        ct_content_management_policy = ct.c_char_p(content_management_policy.encode())  # const char *xmlConfigString
         gw_return_object = glasswall.GwReturnObj()
+        gw_return_object.input_buffer = ct.create_string_buffer(input_file_bytes)
+        gw_return_object.input_buffer_length = ct.c_size_t(len(input_file_bytes))
+        gw_return_object.output_buffer = ct.c_void_p()
+        gw_return_object.output_buffer_length = ct.c_size_t()
+        gw_return_object.output_report_buffer = ct.c_void_p()
+        gw_return_object.output_report_buffer_length = ct.c_size_t()
+        gw_return_object.content_management_policy = ct.c_char_p(content_management_policy.encode())
 
         with utils.CwdHandler(new_cwd=self.library_path):
             # API call
             gw_return_object.status = self.library.GwFileExportArchive(
-                ct.byref(ct_input_buffer),
-                ct_input_buffer_length,
-                ct.byref(ct_output_buffer),
-                ct.byref(ct_output_buffer_length),
-                ct.byref(ct_output_report_buffer),
-                ct.byref(ct_output_report_buffer_length),
-                ct_content_management_policy
+                gw_return_object.input_buffer,
+                gw_return_object.input_buffer_length,
+                ct.byref(gw_return_object.output_buffer),
+                ct.byref(gw_return_object.output_buffer_length),
+                ct.byref(gw_return_object.output_report_buffer),
+                ct.byref(gw_return_object.output_report_buffer_length),
+                gw_return_object.content_management_policy
             )
+
+        if gw_return_object.output_buffer and gw_return_object.output_buffer_length:
+            gw_return_object.output_file = utils.buffer_to_bytes(
+                gw_return_object.output_buffer,
+                gw_return_object.output_buffer_length
+            )
+        if gw_return_object.output_report_buffer and gw_return_object.output_report_buffer_length:
+            gw_return_object.output_report = utils.buffer_to_bytes(
+                gw_return_object.output_report_buffer,
+                gw_return_object.output_report_buffer_length
+            )
+
+        # Write output file
+        if hasattr(gw_return_object, "output_file"):
+            if isinstance(output_file, str):
+                os.makedirs(os.path.dirname(output_file), exist_ok=True)
+                with open(output_file, "wb") as f:
+                    f.write(gw_return_object.output_file)
+
+        # Write output report
+        if hasattr(gw_return_object, "output_report"):
+            if isinstance(output_report, str):
+                os.makedirs(os.path.dirname(output_report), exist_ok=True)
+                with open(output_report, "wb") as f:
+                    f.write(gw_return_object.output_report)
 
         input_file_repr = f"{type(input_file)} length {len(input_file)}" if isinstance(input_file, (bytes, bytearray,)) else input_file.__sizeof__() if isinstance(input_file, io.BytesIO) else input_file
         if gw_return_object.status not in successes.success_codes:
@@ -723,29 +747,6 @@ class ArchiveManager(Library):
                 raise errors.error_codes.get(gw_return_object.status, errors.UnknownErrorCode)(gw_return_object.status)
         else:
             log.debug(f"\n\tinput_file: {input_file_repr}\n\toutput_file: {output_file}\n\tstatus: {gw_return_object.status}")
-
-        gw_return_object.output_file = utils.buffer_to_bytes(
-            ct_output_buffer,
-            ct_output_buffer_length
-        )
-        gw_return_object.output_report = utils.buffer_to_bytes(
-            ct_output_report_buffer,
-            ct_output_report_buffer_length
-        )
-
-        # Write output file
-        if gw_return_object.output_file:
-            if isinstance(output_file, str):
-                os.makedirs(os.path.dirname(output_file), exist_ok=True)
-                with open(output_file, "wb") as f:
-                    f.write(gw_return_object.output_file)
-
-        # Write output report
-        if gw_return_object.output_report:
-            if isinstance(output_report, str):
-                os.makedirs(os.path.dirname(output_report), exist_ok=True)
-                with open(output_report, "wb") as f:
-                    f.write(gw_return_object.output_report)
 
         self.release()
 

--- a/glasswall/libraries/archive_manager/archive_manager.py
+++ b/glasswall/libraries/archive_manager/archive_manager.py
@@ -148,7 +148,7 @@ class ArchiveManager(Library):
             raise_unsupported (bool, optional): Default True. Raise exceptions when Glasswall encounters an error. Fail silently if False.
 
         Returns:
-            gw_return_object (glasswall.GwReturnObj): An instance of class glasswall.GwReturnObj containing attributes: "status" (int), "output_file" (bytes), "output_report" (bytes)
+            gw_return_object (glasswall.GwReturnObj): An instance of class glasswall.GwReturnObj containing attributes including: "status" (int), "output_file" (bytes), "output_report" (bytes)
         """
         # Validate arg types
         if not isinstance(input_file, (str, bytes, bytearray, io.BytesIO)):
@@ -299,7 +299,7 @@ class ArchiveManager(Library):
             raise_unsupported (bool, optional): Default True. Raise exceptions when Glasswall encounters an error. Fail silently if False.
 
         Returns:
-            gw_return_object (glasswall.GwReturnObj): An instance of class glasswall.GwReturnObj containing attributes: "status" (int), "output_file" (bytes), "output_report" (bytes)
+            gw_return_object (glasswall.GwReturnObj): An instance of class glasswall.GwReturnObj containing attributes including: "status" (int), "output_file" (bytes), "output_report" (bytes)
         """
         # Validate arg types
         if not isinstance(input_file, (str, bytes, bytearray, io.BytesIO)):
@@ -646,7 +646,7 @@ class ArchiveManager(Library):
             raise_unsupported (bool, optional): Default True. Raise exceptions when Glasswall encounters an error. Fail silently if False.
 
         Returns:
-            gw_return_object (glasswall.GwReturnObj): An instance of class glasswall.GwReturnObj containing attributes: "status" (int), "output_file" (bytes), "output_report" (bytes)
+            gw_return_object (glasswall.GwReturnObj): An instance of class glasswall.GwReturnObj containing attributes including: "status" (int), "output_file" (bytes), "output_report" (bytes)
         """
         # Validate arg types
         if not isinstance(input_file, (str, bytes, bytearray, io.BytesIO)):
@@ -798,7 +798,7 @@ class ArchiveManager(Library):
             raise_unsupported (bool, optional): Default True. Raise exceptions when Glasswall encounters an error. Fail silently if False.
 
         Returns:
-            gw_return_object (glasswall.GwReturnObj): An instance of class glasswall.GwReturnObj containing attributes: "status" (int), "output_file" (bytes), "output_report" (bytes)
+            gw_return_object (glasswall.GwReturnObj): An instance of class glasswall.GwReturnObj containing attributes including: "status" (int), "output_file" (bytes), "output_report" (bytes)
         """
         # Validate arg types
         if not isinstance(input_file, (str, bytes, bytearray, io.BytesIO)):


### PR DESCRIPTION
Changes the default value for import_archive's include_analysis_report argument from True to False.
Minor code refactor.
Change to functionality: If ArchiveManager fails to process a file but the output_report_buffer and output_report_buffer_length are populated, the report will now be written prior to an exception being raised.

Internal: resolves issue in 148168.