### PR TITLE
Users/aroberts/update editor content management policy from xsd

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 import platform
 import tempfile
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()

--- a/glasswall/content_management/config_elements/__init__.py
+++ b/glasswall/content_management/config_elements/__init__.py
@@ -5,9 +5,11 @@ from glasswall.content_management.config_elements.config_element import ConfigEl
 from glasswall.content_management.config_elements.gifConfig import gifConfig
 from glasswall.content_management.config_elements.pdfConfig import pdfConfig
 from glasswall.content_management.config_elements.pptConfig import pptConfig
+from glasswall.content_management.config_elements.svgConfig import svgConfig
 from glasswall.content_management.config_elements.sysConfig import sysConfig
 from glasswall.content_management.config_elements.textList import textList
 from glasswall.content_management.config_elements.textSearchConfig import textSearchConfig
 from glasswall.content_management.config_elements.tiffConfig import tiffConfig
+from glasswall.content_management.config_elements.webpConfig import webpConfig
 from glasswall.content_management.config_elements.wordConfig import wordConfig
 from glasswall.content_management.config_elements.xlsConfig import xlsConfig

--- a/glasswall/content_management/config_elements/pdfConfig.py
+++ b/glasswall/content_management/config_elements/pdfConfig.py
@@ -29,6 +29,8 @@ class pdfConfig(ConfigElement):
             self.switches_module.internal_hyperlinks(value=default),
             self.switches_module.javascript(value=default),
             self.switches_module.metadata(value=default),
+            self.switches_module.value_outside_reasonable_limits(value=default),
+            self.switches_module.watermark(value=""),
         ]
 
         super().__init__(

--- a/glasswall/content_management/config_elements/pptConfig.py
+++ b/glasswall/content_management/config_elements/pptConfig.py
@@ -24,7 +24,6 @@ class pptConfig(ConfigElement):
             self.switches_module.embedded_images(value=default),
             self.switches_module.external_hyperlinks(value=default),
             self.switches_module.internal_hyperlinks(value=default),
-            self.switches_module.javascript(value=default),
             self.switches_module.macros(value=default),
             self.switches_module.metadata(value=default),
             self.switches_module.review_comments(value=default),

--- a/glasswall/content_management/config_elements/svgConfig.py
+++ b/glasswall/content_management/config_elements/svgConfig.py
@@ -4,31 +4,25 @@ from glasswall.content_management import switches
 from glasswall.content_management.config_elements.config_element import ConfigElement
 
 
-class xlsConfig(ConfigElement):
-    """ An xlsConfig ConfigElement.
+class svgConfig(ConfigElement):
+    """ A svgConfig ConfigElement.
 
     Args:
         default (str): The default action: allow, disallow, or sanitise.
 
     Key word arguments can be specified to change individual switch values:
-    xlsConfig(default="allow", embedded_images="sanitise")
+    svgConfig(default="allow", embedded_images="sanitise")
     """
 
     def __init__(self, default: str = "sanitise", attributes: dict = {}, **kwargs):
         self.name = self.__class__.__name__
         self.default = default
         self.attributes = attributes
-        self.switches_module = switches.xls
+        self.switches_module = switches.svg
         self.default_switches = [
-            self.switches_module.connections(value=default),
-            self.switches_module.dynamic_data_exchange(value=default),
-            self.switches_module.embedded_files(value=default),
-            self.switches_module.embedded_images(value=default),
-            self.switches_module.external_hyperlinks(value=default),
-            self.switches_module.internal_hyperlinks(value=default),
-            self.switches_module.macros(value=default),
-            self.switches_module.metadata(value=default),
-            self.switches_module.review_comments(value=default),
+            self.switches_module.foreign_objects(value=default),
+            self.switches_module.hyperlinks(value=default),
+            self.switches_module.scripts(value=default),
         ]
 
         super().__init__(

--- a/glasswall/content_management/config_elements/sysConfig.py
+++ b/glasswall/content_management/config_elements/sysConfig.py
@@ -17,11 +17,12 @@ class sysConfig(ConfigElement):
 
         self.switches_module = switches.sys
         self.default_switches = [
-            self.switches_module.interchange_type(value="sisl"),
-            self.switches_module.interchange_pretty(value="false"),
-            self.switches_module.interchange_best_compression(value="false"),
+            self.switches_module.enable_sha256(value="true"),
             self.switches_module.export_embedded_images(value="true"),
-            self.switches_module.run_mode(value="enablerebuild")
+            self.switches_module.interchange_best_compression(value="false"),
+            self.switches_module.interchange_pretty(value="false"),
+            self.switches_module.interchange_type(value="sisl"),
+            self.switches_module.run_mode(value="enablerebuild"),
         ]
 
         super().__init__(

--- a/glasswall/content_management/config_elements/webpConfig.py
+++ b/glasswall/content_management/config_elements/webpConfig.py
@@ -4,31 +4,23 @@ from glasswall.content_management import switches
 from glasswall.content_management.config_elements.config_element import ConfigElement
 
 
-class xlsConfig(ConfigElement):
-    """ An xlsConfig ConfigElement.
+class webpConfig(ConfigElement):
+    """ A webpConfig ConfigElement.
 
     Args:
         default (str): The default action: allow, disallow, or sanitise.
 
     Key word arguments can be specified to change individual switch values:
-    xlsConfig(default="allow", embedded_images="sanitise")
+    webpConfig(default="allow", embedded_images="sanitise")
     """
 
     def __init__(self, default: str = "sanitise", attributes: dict = {}, **kwargs):
         self.name = self.__class__.__name__
         self.default = default
         self.attributes = attributes
-        self.switches_module = switches.xls
+        self.switches_module = switches.webp
         self.default_switches = [
-            self.switches_module.connections(value=default),
-            self.switches_module.dynamic_data_exchange(value=default),
-            self.switches_module.embedded_files(value=default),
-            self.switches_module.embedded_images(value=default),
-            self.switches_module.external_hyperlinks(value=default),
-            self.switches_module.internal_hyperlinks(value=default),
-            self.switches_module.macros(value=default),
             self.switches_module.metadata(value=default),
-            self.switches_module.review_comments(value=default),
         ]
 
         super().__init__(

--- a/glasswall/content_management/policies/editor.py
+++ b/glasswall/content_management/policies/editor.py
@@ -13,8 +13,10 @@ class Editor(Policy):
             glasswall.content_management.config_elements.gifConfig(default=default),
             glasswall.content_management.config_elements.pdfConfig(default=default),
             glasswall.content_management.config_elements.pptConfig(default=default),
+            glasswall.content_management.config_elements.svgConfig(default=default),
             glasswall.content_management.config_elements.sysConfig(),
             glasswall.content_management.config_elements.tiffConfig(default=default),
+            glasswall.content_management.config_elements.webpConfig(default=default),
             glasswall.content_management.config_elements.wordConfig(default=default),
             glasswall.content_management.config_elements.xlsConfig(default=default),
         ]

--- a/glasswall/content_management/switches/__init__.py
+++ b/glasswall/content_management/switches/__init__.py
@@ -1,4 +1,4 @@
 
 
-from glasswall.content_management.switches import archive, gif, pdf, ppt, sys, tiff, word, xls
+from glasswall.content_management.switches import archive, gif, pdf, ppt, svg, sys, tiff, webp, word, xls
 from glasswall.content_management.switches.switch import Switch

--- a/glasswall/content_management/switches/pdf.py
+++ b/glasswall/content_management/switches/pdf.py
@@ -73,3 +73,19 @@ class metadata(Switch):
         self.restrict_values = ["allow", "disallow", "sanitise"]
         self.value = value
         super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
+
+
+class value_outside_reasonable_limits(Switch):
+    def __init__(self, value: str):
+        self.name = self.__class__.__name__
+        self.restrict_values = ["allow", "disallow", "sanitise"]
+        self.value = value
+        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
+
+
+class watermark(Switch):
+    def __init__(self, value: str):
+        self.name = self.__class__.__name__
+        self.restrict_values = None
+        self.value = value
+        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)

--- a/glasswall/content_management/switches/ppt.py
+++ b/glasswall/content_management/switches/ppt.py
@@ -35,14 +35,6 @@ class internal_hyperlinks(Switch):
         super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
 
 
-class javascript(Switch):
-    def __init__(self, value: str):
-        self.name = self.__class__.__name__
-        self.restrict_values = ["allow", "disallow", "sanitise"]
-        self.value = value
-        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
-
-
 class macros(Switch):
     def __init__(self, value: str):
         self.name = self.__class__.__name__

--- a/glasswall/content_management/switches/svg.py
+++ b/glasswall/content_management/switches/svg.py
@@ -1,0 +1,27 @@
+
+
+from glasswall.content_management.switches.switch import Switch
+
+
+class foreign_objects(Switch):
+    def __init__(self, value: str):
+        self.name = self.__class__.__name__
+        self.restrict_values = ["allow", "disallow", "sanitise"]
+        self.value = value
+        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
+
+
+class hyperlinks(Switch):
+    def __init__(self, value: str):
+        self.name = self.__class__.__name__
+        self.restrict_values = ["allow", "disallow", "sanitise"]
+        self.value = value
+        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
+
+
+class scripts(Switch):
+    def __init__(self, value: str):
+        self.name = self.__class__.__name__
+        self.restrict_values = ["allow", "disallow", "sanitise"]
+        self.value = value
+        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)

--- a/glasswall/content_management/switches/sys.py
+++ b/glasswall/content_management/switches/sys.py
@@ -3,15 +3,15 @@
 from glasswall.content_management.switches.switch import Switch
 
 
-class interchange_type(Switch):
+class enable_sha256(Switch):
     def __init__(self, value: str):
         self.name = self.__class__.__name__
-        self.restrict_values = ["sisl", "xml"]
+        self.restrict_values = ["false", "true"]
         self.value = value
         super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
 
 
-class interchange_pretty(Switch):
+class export_embedded_images(Switch):
     def __init__(self, value: str):
         self.name = self.__class__.__name__
         self.restrict_values = ["false", "true"]
@@ -27,10 +27,18 @@ class interchange_best_compression(Switch):
         super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
 
 
-class export_embedded_images(Switch):
+class interchange_pretty(Switch):
     def __init__(self, value: str):
         self.name = self.__class__.__name__
         self.restrict_values = ["false", "true"]
+        self.value = value
+        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
+
+
+class interchange_type(Switch):
+    def __init__(self, value: str):
+        self.name = self.__class__.__name__
+        self.restrict_values = ["sisl", "xml"]
         self.value = value
         super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
 

--- a/glasswall/content_management/switches/webp.py
+++ b/glasswall/content_management/switches/webp.py
@@ -1,0 +1,11 @@
+
+
+from glasswall.content_management.switches.switch import Switch
+
+
+class metadata(Switch):
+    def __init__(self, value: str):
+        self.name = self.__class__.__name__
+        self.restrict_values = ["allow", "disallow", "sanitise"]
+        self.value = value
+        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)

--- a/glasswall/content_management/switches/xls.py
+++ b/glasswall/content_management/switches/xls.py
@@ -3,6 +3,14 @@
 from glasswall.content_management.switches.switch import Switch
 
 
+class connections(Switch):
+    def __init__(self, value: str):
+        self.name = self.__class__.__name__
+        self.restrict_values = ["allow", "disallow", "sanitise"]
+        self.value = value
+        super().__init__(name=self.name, value=self.value, restrict_values=self.restrict_values)
+
+
 class dynamic_data_exchange(Switch):
     def __init__(self, value: str):
         self.name = self.__class__.__name__


### PR DESCRIPTION
Updates the default Editor content management policy based on the latest XSD.

Before / after:

![image](https://github.com/gw-engineering/glasswall-python-wrapper/assets/46464807/b88d8f9c-37b7-4710-94ee-b1d92c77955e)
