### PR TITLE
add attribute input_file_path to _GW2RegisterInputFile return

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 import platform
 import tempfile
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()

--- a/glasswall/libraries/editor/editor.py
+++ b/glasswall/libraries/editor/editor.py
@@ -426,6 +426,7 @@ class Editor(Library):
         gw_return_object = glasswall.GwReturnObj()
         gw_return_object.session = ct.c_size_t(session)
         gw_return_object.input_file = ct.c_char_p(input_file.encode("utf-8"))
+        gw_return_object.input_file_path = input_file
 
         # API call
         gw_return_object.status = self.library.GW2RegisterInputFile(


### PR DESCRIPTION
Adds attribute "input_file_path" to the return of Editor's "_GW2RegisterInputFile" function. This improves the error messaging when registering of an input file fails:

```
2023-12-18 14:11:10.865 glasswall.config.logging        ERROR           register_input
        session: c_ulonglong(2)
        input_file: c_char_p(3100045171920)
        input_file_path: C:\Users\AngusRoberts\Documents\GitHub\glasswall\empty.txt
        status: -6
```