### PR TITLE
Add jpegConfig policy to default_config_elements[]

### DIFF
--- a/glasswall/content_management/policies/editor.py
+++ b/glasswall/content_management/policies/editor.py
@@ -19,6 +19,7 @@ class Editor(Policy):
             glasswall.content_management.config_elements.webpConfig(default=default),
             glasswall.content_management.config_elements.wordConfig(default=default),
             glasswall.content_management.config_elements.xlsConfig(default=default),
+            glasswall.content_management.config_elements.jpegConfig(default=default),
         ]
         self.config = config or {}
 


### PR DESCRIPTION
File format JPEG now has policy jpegConfig with the usual default switch setting.